### PR TITLE
chore: bump libADLMIDI to 73d046d

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "libadlmidi": {
     "version": "1.6.2",
-    "commit": "89284b0b63e236ccaf84ac2763574738840d37b4"
+    "commit": "73d046d58d5ea20834caa48d034da206e5a628a0"
   },
   "description": "WebAssembly build of libADLMIDI - OPL3/FM synthesis for the browser",
   "main": "dist/libadlmidi.js",


### PR DESCRIPTION
- `395248e` feat: add `adl_barechip_*` C API exposing nuked-opl3 directly (#310)
- `bfd3496` Minor code style polishing
- `98eb128` MIDI Seq: fix incorrect loop end position when last track is shorter than others
- `dd4d8b7` MIDIPlay: apply gaining to recorded WAV files (utils only, not compiled into WASM)
- `73d046d` MIDIPlay: allow record WAVs in any format and spec (utils only, not compiled into WASM)