### PR TITLE
fix: pin @emnapi/core and @emnapi/runtime as devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "2.0.0",
       "license": "LGPL-3.0",
       "devDependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
         "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.57.0",
         "@types/node": "^25.0.3",
@@ -20,13 +22,35 @@
         "vitest": "^4.1.5"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2431,8 +2455,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,8 @@
     "url": "https://github.com/libadlmidi-js/libadlmidi-js.git"
   },
   "devDependencies": {
+    "@emnapi/core": "1.10.0",
+    "@emnapi/runtime": "1.10.0",
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.57.0",
     "@types/node": "^25.0.3",


### PR DESCRIPTION
`@rolldown/binding-wasm32-wasi` (pulled in via vitest 4.1.5) declares `@emnapi/core@1.10.0` and `@emnapi/runtime@1.10.0` as deps, but on non-wasm32 hosts npm skips materializing them as standalone lockfile entries. Older npm versions (CI's node 24) treat the gap as out-of-sync and fail `npm ci` with EUSAGE. Pinning them as direct devDependencies forces proper lockfile entries.

See [oxc-project/oxc#21038](https://github.com/oxc-project/oxc/issues/21038), [napi-rs/napi-rs#3174](https://github.com/napi-rs/napi-rs/pull/3174).