### PR TITLE
ci: speed up Playwright setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,19 +180,42 @@ jobs:
       - name: Run unit tests
         run: npm test
 
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps
+      - name: Run bundler smoke test
+        run: npm run test:bundler
+
+  browser-test:
+    needs: [lint, js-build]
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Download dist artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '24.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps --only-shell chromium
 
       - name: Run browser tests
         run: npm run test:browser
-
-      - name: Run bundler smoke test
-        run: npm run test:bundler
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: ${{ !cancelled() }}
         with:
-          name: playwright-report-${{ matrix.node-version }}
+          name: playwright-report
           path: playwright-report/
           retention-days: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         run: npm test
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps
+        run: npx playwright install --with-deps --only-shell chromium
 
       - name: Run browser tests
         run: npm run test:browser


### PR DESCRIPTION
## Summary

- Move Playwright browser tests out of the Node.js version matrix so the browser setup runs once per CI run.
- Install only Chromium's headless shell for Playwright, matching the Chromium-only browser test config.
- Apply the same narrower Playwright install command in the release workflow.

## Why

The CI browser job was installing Playwright browsers and system dependencies once for each Node matrix entry, and the install command was downloading the default browser set even though the test config only defines a Chromium project.

## Validation

- `git diff --check -- .github/workflows/ci.yml .github/workflows/release.yml`
- Parsed both workflow YAML files with Ruby's YAML loader.
- Commit hook ran and passed GitHub Actions workflow linting.