### PR TITLE
chore: port Nuked-OPL3-fast as the Nuked OPL3 v1.8 implementation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "libADLMIDI"]
 	path = libADLMIDI
-	url = https://github.com/Wohlstand/libADLMIDI.git
+	url = https://github.com/tgies/libADLMIDI.git
+	branch = nuked-opl3-fast-port

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "libadlmidi": {
     "version": "1.6.2",
-    "commit": "73d046d58d5ea20834caa48d034da206e5a628a0"
+    "commit": "5d03efe56dc9044f5bb010007d2023cbb38e8ae6"
   },
   "description": "WebAssembly build of libADLMIDI - OPL3/FM synthesis for the browser",
   "main": "dist/libadlmidi.js",

--- a/tests/fixtures/test-vectors.json
+++ b/tests/fixtures/test-vectors.json
@@ -1,6 +1,6 @@
 {
     "_comment": "Golden master test vectors for libADLMIDI-JS audio output verification",
-    "_generated": "2025-12-20",
+    "_generated": "2026-05-13",
     "_note": "These hashes are captured from known-good renders. If they change unexpectedly, it may indicate a regression.",
     "browser": {
         "note_c4_bank72_500ms": {
@@ -17,13 +17,13 @@
             "description": "mamsnake.imf (Wolf3D music) playback for 3 seconds",
             "file": "test-files/mamsnake.imf",
             "durationMs": 3000,
-            "hash": "6481c2fbe60e4dc4af668365bf7d2db9c4330d03f9a1416dfb5b6f29972b4b72"
+            "hash": "aa25dde84973da57c4126513b6e5418a9165f31163c8c21bb68f14860de3934b"
         },
         "midi_canyon_3s": {
             "description": "canyon.mid (classic Windows MIDI) playback for 3 seconds",
             "file": "test-files/canyon.mid",
             "durationMs": 3000,
-            "hash": "eefe36e91c053272dcb4ee8ab1c1c8b89cfa0a916f13db6d49953f99b40130ea"
+            "hash": "e7514fe96bd0e4800926642a772e24115a362f5fe06e4a62d5a92a7968105359"
         }
     },
     "node": {


### PR DESCRIPTION
Submodule now points at `tgies/libADLMIDI` `nuked-opl3-fast-port` (a fork of `Wohlstand/libADLMIDI` master), which replaces the vendored Nuked-OPL3 v1.8 with a perf-optimized version of upstream Nuked-OPL3 v1.8 (cfedb09).

Speedup vs. previous Nuked v1.8 (median of 5 runs, full-length render through `AdlMidiCore.play`):

| File | Previous | New | Speedup |
| --- | --- | --- | --- |
| `canyon.mid` (122s MIDI) | 22.80x realtime | 32.84x realtime | 1.44x |
| `mamsnake.imf` (40s raw OPL) | 48.32x realtime | 79.95x realtime | 1.66x |

Audio output changes. New version pulls in two upstream Nuked envelope bugfixes (`cfedb09`, `e4afafc`) that the prior libADLMIDI vendoring never picked up. Output differs from the old hashes but is audibly equivalent - the difference is concentrated in note attack transients reflecting the corrected envelope generator. The two browser fixture hashes are re-baselined accordingly.