### PR TITLE
chore: track upstream libADLMIDI and default to NUKED_FAST

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "libADLMIDI"]
 	path = libADLMIDI
-	url = https://github.com/tgies/libADLMIDI.git
-	branch = nuked-opl3-fast-port
+	url = https://github.com/Wohlstand/libADLMIDI.git

--- a/README.md
+++ b/README.md
@@ -139,10 +139,12 @@ const decoded = decodeInstrument(bytes);
 
 | Profile | Emulator(s) | Usage |
 |---------|-------------|-------|
-| `nuked` | Nuked OPL3 v1.8 | Maximum accuracy, highest CPU usage. |
+| `nuked` | Nuked OPL3 v1.8 + Nuked OPL3 Fast | Maximum accuracy. Defaults to Nuked Fast (bit-exact vs Nuked 1.8, faster). |
 | `dosbox` | DosBox OPL3 | Great balance of speed and accuracy. |
-| `light` | Nuked + DosBox | Flexible for varied performance needs. |
-| `full` | All supported | Includes Opal, Java OPL3, ESFMu, etc. |
+| `light` | Nuked + Nuked Fast, DosBox | Flexible for varied performance needs. Defaults to Nuked Fast. |
+| `full` | All supported | Includes Opal, Java OPL3, ESFMu, etc. Defaults to Nuked Fast where available. |
+
+To opt back to the original Nuked 1.8, pass `{ emulator: Emulator.NUKED }` as the third argument to `init()`, or call `await synth.switchEmulator(Emulator.NUKED)` after init.
 
 ## Documentation
 

--- a/examples/oplsfxr.html
+++ b/examples/oplsfxr.html
@@ -1063,6 +1063,7 @@
                             <label for="emulatorSelect">Emulator</label>
                             <select id="emulatorSelect">
                                 <option value="0" selected>Nuked OPL3</option>
+                                <option value="1">Nuked OPL3 Fast</option>
                                 <option value="2">DosBox OPL3</option>
                                 <option value="3">Opal (Reality Adlib)</option>
                                 <option value="4">Java OPL3</option>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "libadlmidi": {
     "version": "1.6.2",
-    "commit": "0009c22fd5f3eda9005d270d6eeab3f19caa35bd"
+    "commit": "6528dafce641e81ded5d62809445267b82dc0d8d"
   },
   "description": "WebAssembly build of libADLMIDI - OPL3/FM synthesis for the browser",
   "main": "dist/libadlmidi.js",

--- a/scripts/generate-profiles.js
+++ b/scripts/generate-profiles.js
@@ -11,16 +11,37 @@ import path from 'path';
 const PROFILES = ['nuked', 'dosbox', 'light', 'full'];
 const VARIANTS = ['', '.slim'];
 
+// Emulator.NUKED_FAST value. Hardcoded to avoid importing constants.js at
+// build time. Must stay in sync with src/utils/constants.js.
+const NUKED_FAST = 1;
+
+// Profiles that bundle the Nuked Fast variant get it as their runtime default.
+// dosbox does not include Nuked at all, so it keeps the libADLMIDI default
+// (whichever DosBox enum value is wired up by the compiled-in set).
+const PROFILE_DEFAULT_EMULATOR = {
+    nuked: NUKED_FAST,
+    light: NUKED_FAST,
+    full: NUKED_FAST,
+    dosbox: undefined,
+};
+
 function generateProfileWrapper(profile, slim = false) {
     const suffix = slim ? '.slim' : '';
     const profileName = `${profile}${suffix}`;
+    const defaultEmulator = PROFILE_DEFAULT_EMULATOR[profile];
+    const defaultsLiteral = defaultEmulator !== undefined
+        ? `{ emulator: ${defaultEmulator} }`
+        : '{}';
+    const coreDefaultArg = defaultEmulator !== undefined
+        ? `, defaultEmulator: options.defaultEmulator !== undefined ? options.defaultEmulator : ${defaultEmulator}`
+        : '';
 
     return `/**
  * Zero-config ${profile}${slim ? ' (slim)' : ''} profile for libADLMIDI-JS
- * 
+ *
  * Exports pre-configured AdlMidi and AdlMidiCore with this profile's WASM.
  * ${slim ? 'Slim builds require loading a WOPL bank at runtime.' : ''}
- * 
+ *
  * @module profiles/${profileName}
  */
 
@@ -31,6 +52,10 @@ import { AdlMidiCore as BaseAdlMidiCore } from '../core.js';
 const PROCESSOR_URL = new URL('../../dist/libadlmidi.${profile}${suffix}.processor.js', import.meta.url).href;
 const WASM_URL = new URL('../../dist/libadlmidi.${profile}${suffix}.core.wasm', import.meta.url).href;
 const CORE_PATH = new URL('../../dist/libadlmidi.${profile}${suffix}.core.js', import.meta.url).href;
+
+// Default synth settings injected at init. NUKED_FAST is preferred when the
+// profile bundles it (bit-exact vs Nuked 1.8, roughly 1.5x faster).
+const DEFAULT_SETTINGS = ${defaultsLiteral};
 
 /**
  * Pre-configured AdlMidi for ${profile}${slim ? ' slim' : ''} profile.
@@ -47,15 +72,17 @@ const CORE_PATH = new URL('../../dist/libadlmidi.${profile}${suffix}.core.js', i
 export class AdlMidi extends BaseAdlMidi {
     /**
      * Initialize the synthesizer with this profile's WASM.
-     * 
+     *
      * @param {string} [processorUrl] - Override processor URL (optional)
      * @param {string} [wasmUrl] - Override WASM URL (optional)
+     * @param {object} [defaultSettings] - Override profile's default synth settings
      * @returns {Promise<void>}
      */
-    async init(processorUrl, wasmUrl) {
+    async init(processorUrl, wasmUrl, defaultSettings) {
         return super.init(
             processorUrl || PROCESSOR_URL,
-            wasmUrl || WASM_URL
+            wasmUrl || WASM_URL,
+            defaultSettings || DEFAULT_SETTINGS
         );
     }
 }
@@ -77,13 +104,14 @@ export class AdlMidiCore {
     /**
      * Create a new AdlMidiCore instance with this profile's WASM.
      * 
-     * @param {{corePath?: string}} [options] - Options (corePath is pre-configured)
+     * @param {{corePath?: string, defaultEmulator?: number, wasmBinary?: ArrayBuffer}} [options]
+     *   Override profile defaults. corePath and defaultEmulator are pre-configured.
      * @returns {Promise<BaseAdlMidiCore>}
      */
     static async create(options = {}) {
         return BaseAdlMidiCore.create({
             ...options,
-            corePath: options.corePath || CORE_PATH
+            corePath: options.corePath || CORE_PATH${coreDefaultArg}
         });
     }
 }

--- a/src/core.js
+++ b/src/core.js
@@ -51,6 +51,8 @@ export class AdlMidiCore {
      * @param {Object} options
      * @param {string} options.corePath - Path to the .core.js WASM loader module
      * @param {ArrayBuffer} [options.wasmBinary] - Pre-loaded WASM binary (optional)
+     * @param {number} [options.defaultEmulator] - Emulator to switch to after init.
+     *                            Profile wrappers use this to default to NUKED_FAST.
      * @returns {Promise<AdlMidiCore>}
      */
     static async create(options) {
@@ -73,6 +75,7 @@ export class AdlMidiCore {
         core._sampleRate = 44100;
         core._audioBuffer = null;
         core._audioBufferPtr = null;
+        core._defaultEmulator = options.defaultEmulator;
 
         return core;
     }
@@ -88,6 +91,8 @@ export class AdlMidiCore {
         this._audioBuffer = null;
         /** @private @type {number|null} */
         this._audioBufferPtr = null;
+        /** @private @type {number|undefined} */
+        this._defaultEmulator = undefined;
     }
 
     /**
@@ -106,6 +111,10 @@ export class AdlMidiCore {
 
         if (!this._player) {
             throw new Error('Failed to initialize ADL MIDI player');
+        }
+
+        if (this._defaultEmulator !== undefined) {
+            this._module._adl_switchEmulator(this._player, this._defaultEmulator);
         }
 
         return true;

--- a/src/libadlmidi.js
+++ b/src/libadlmidi.js
@@ -114,9 +114,11 @@ export class AdlMidi {
      * @param {string} processorUrl - URL to the bundled processor JavaScript file
      * @param {string | null} [wasmUrl=null] - Optional URL to the .wasm file for split builds.
      *                             If not provided, assumes bundled version with embedded WASM.
+     * @param {object} [defaultSettings={}] - Initial synth settings applied before ready.
+     *                             Profile wrappers use this to set a default emulator.
      * @returns {Promise<void>}
      */
-    async init(processorUrl, wasmUrl = null) {
+    async init(processorUrl, wasmUrl = null, defaultSettings = {}) {
         if (!this.ctx) {
             this.ctx = new AudioContext({ sampleRate: 44100 });
         }
@@ -143,7 +145,8 @@ export class AdlMidi {
         this.node = new AudioWorkletNode(this.ctx, 'adl-midi-processor', {
             processorOptions: {
                 sampleRate: this.ctx.sampleRate,
-                wasmBinary: wasmBinary  // null for bundled, ArrayBuffer for split
+                wasmBinary: wasmBinary,  // null for bundled, ArrayBuffer for split
+                settings: defaultSettings
             }
         });
 

--- a/src/processor.js
+++ b/src/processor.js
@@ -45,6 +45,7 @@ class AdlMidiProcessor extends AudioWorkletProcessor {
             softPan: true,            // Soft stereo panning
             deepVibrato: false,       // Deep vibrato
             deepTremolo: false,       // Deep tremolo
+            emulator: undefined,      // Emulator core (undefined = libADLMIDI default)
             ...options.processorOptions?.settings
         };
 
@@ -104,6 +105,11 @@ class AdlMidiProcessor extends AudioWorkletProcessor {
     applySettings(settings) {
         if (!this.midi) return;
 
+        // Switch emulator first; adl_switchEmulator does a partialReset and a
+        // wrong-order subsequent setBank etc. would otherwise need re-applying.
+        if (settings.emulator !== undefined) {
+            this.adl._adl_switchEmulator(this.midi, settings.emulator);
+        }
         if (settings.numChips !== undefined) {
             this.adl._adl_setNumChips(this.midi, settings.numChips);
         }

--- a/src/profiles/dosbox.js
+++ b/src/profiles/dosbox.js
@@ -1,9 +1,9 @@
 /**
  * Zero-config dosbox profile for libADLMIDI-JS
- * 
+ *
  * Exports pre-configured AdlMidi and AdlMidiCore with this profile's WASM.
  * 
- * 
+ *
  * @module profiles/dosbox
  */
 
@@ -14,6 +14,10 @@ import { AdlMidiCore as BaseAdlMidiCore } from '../core.js';
 const PROCESSOR_URL = new URL('../../dist/libadlmidi.dosbox.processor.js', import.meta.url).href;
 const WASM_URL = new URL('../../dist/libadlmidi.dosbox.core.wasm', import.meta.url).href;
 const CORE_PATH = new URL('../../dist/libadlmidi.dosbox.core.js', import.meta.url).href;
+
+// Default synth settings injected at init. NUKED_FAST is preferred when the
+// profile bundles it (bit-exact vs Nuked 1.8, roughly 1.5x faster).
+const DEFAULT_SETTINGS = {};
 
 /**
  * Pre-configured AdlMidi for dosbox profile.
@@ -30,15 +34,17 @@ const CORE_PATH = new URL('../../dist/libadlmidi.dosbox.core.js', import.meta.ur
 export class AdlMidi extends BaseAdlMidi {
     /**
      * Initialize the synthesizer with this profile's WASM.
-     * 
+     *
      * @param {string} [processorUrl] - Override processor URL (optional)
      * @param {string} [wasmUrl] - Override WASM URL (optional)
+     * @param {object} [defaultSettings] - Override profile's default synth settings
      * @returns {Promise<void>}
      */
-    async init(processorUrl, wasmUrl) {
+    async init(processorUrl, wasmUrl, defaultSettings) {
         return super.init(
             processorUrl || PROCESSOR_URL,
-            wasmUrl || WASM_URL
+            wasmUrl || WASM_URL,
+            defaultSettings || DEFAULT_SETTINGS
         );
     }
 }
@@ -60,7 +66,8 @@ export class AdlMidiCore {
     /**
      * Create a new AdlMidiCore instance with this profile's WASM.
      * 
-     * @param {{corePath?: string}} [options] - Options (corePath is pre-configured)
+     * @param {{corePath?: string, defaultEmulator?: number, wasmBinary?: ArrayBuffer}} [options]
+     *   Override profile defaults. corePath and defaultEmulator are pre-configured.
      * @returns {Promise<BaseAdlMidiCore>}
      */
     static async create(options = {}) {

--- a/src/profiles/dosbox.slim.js
+++ b/src/profiles/dosbox.slim.js
@@ -1,9 +1,9 @@
 /**
  * Zero-config dosbox (slim) profile for libADLMIDI-JS
- * 
+ *
  * Exports pre-configured AdlMidi and AdlMidiCore with this profile's WASM.
  * Slim builds require loading a WOPL bank at runtime.
- * 
+ *
  * @module profiles/dosbox.slim
  */
 
@@ -14,6 +14,10 @@ import { AdlMidiCore as BaseAdlMidiCore } from '../core.js';
 const PROCESSOR_URL = new URL('../../dist/libadlmidi.dosbox.slim.processor.js', import.meta.url).href;
 const WASM_URL = new URL('../../dist/libadlmidi.dosbox.slim.core.wasm', import.meta.url).href;
 const CORE_PATH = new URL('../../dist/libadlmidi.dosbox.slim.core.js', import.meta.url).href;
+
+// Default synth settings injected at init. NUKED_FAST is preferred when the
+// profile bundles it (bit-exact vs Nuked 1.8, roughly 1.5x faster).
+const DEFAULT_SETTINGS = {};
 
 /**
  * Pre-configured AdlMidi for dosbox slim profile.
@@ -30,15 +34,17 @@ const CORE_PATH = new URL('../../dist/libadlmidi.dosbox.slim.core.js', import.me
 export class AdlMidi extends BaseAdlMidi {
     /**
      * Initialize the synthesizer with this profile's WASM.
-     * 
+     *
      * @param {string} [processorUrl] - Override processor URL (optional)
      * @param {string} [wasmUrl] - Override WASM URL (optional)
+     * @param {object} [defaultSettings] - Override profile's default synth settings
      * @returns {Promise<void>}
      */
-    async init(processorUrl, wasmUrl) {
+    async init(processorUrl, wasmUrl, defaultSettings) {
         return super.init(
             processorUrl || PROCESSOR_URL,
-            wasmUrl || WASM_URL
+            wasmUrl || WASM_URL,
+            defaultSettings || DEFAULT_SETTINGS
         );
     }
 }
@@ -60,7 +66,8 @@ export class AdlMidiCore {
     /**
      * Create a new AdlMidiCore instance with this profile's WASM.
      * 
-     * @param {{corePath?: string}} [options] - Options (corePath is pre-configured)
+     * @param {{corePath?: string, defaultEmulator?: number, wasmBinary?: ArrayBuffer}} [options]
+     *   Override profile defaults. corePath and defaultEmulator are pre-configured.
      * @returns {Promise<BaseAdlMidiCore>}
      */
     static async create(options = {}) {

--- a/src/profiles/full.js
+++ b/src/profiles/full.js
@@ -1,9 +1,9 @@
 /**
  * Zero-config full profile for libADLMIDI-JS
- * 
+ *
  * Exports pre-configured AdlMidi and AdlMidiCore with this profile's WASM.
  * 
- * 
+ *
  * @module profiles/full
  */
 
@@ -14,6 +14,10 @@ import { AdlMidiCore as BaseAdlMidiCore } from '../core.js';
 const PROCESSOR_URL = new URL('../../dist/libadlmidi.full.processor.js', import.meta.url).href;
 const WASM_URL = new URL('../../dist/libadlmidi.full.core.wasm', import.meta.url).href;
 const CORE_PATH = new URL('../../dist/libadlmidi.full.core.js', import.meta.url).href;
+
+// Default synth settings injected at init. NUKED_FAST is preferred when the
+// profile bundles it (bit-exact vs Nuked 1.8, roughly 1.5x faster).
+const DEFAULT_SETTINGS = { emulator: 1 };
 
 /**
  * Pre-configured AdlMidi for full profile.
@@ -30,15 +34,17 @@ const CORE_PATH = new URL('../../dist/libadlmidi.full.core.js', import.meta.url)
 export class AdlMidi extends BaseAdlMidi {
     /**
      * Initialize the synthesizer with this profile's WASM.
-     * 
+     *
      * @param {string} [processorUrl] - Override processor URL (optional)
      * @param {string} [wasmUrl] - Override WASM URL (optional)
+     * @param {object} [defaultSettings] - Override profile's default synth settings
      * @returns {Promise<void>}
      */
-    async init(processorUrl, wasmUrl) {
+    async init(processorUrl, wasmUrl, defaultSettings) {
         return super.init(
             processorUrl || PROCESSOR_URL,
-            wasmUrl || WASM_URL
+            wasmUrl || WASM_URL,
+            defaultSettings || DEFAULT_SETTINGS
         );
     }
 }
@@ -60,13 +66,14 @@ export class AdlMidiCore {
     /**
      * Create a new AdlMidiCore instance with this profile's WASM.
      * 
-     * @param {{corePath?: string}} [options] - Options (corePath is pre-configured)
+     * @param {{corePath?: string, defaultEmulator?: number, wasmBinary?: ArrayBuffer}} [options]
+     *   Override profile defaults. corePath and defaultEmulator are pre-configured.
      * @returns {Promise<BaseAdlMidiCore>}
      */
     static async create(options = {}) {
         return BaseAdlMidiCore.create({
             ...options,
-            corePath: options.corePath || CORE_PATH
+            corePath: options.corePath || CORE_PATH, defaultEmulator: options.defaultEmulator !== undefined ? options.defaultEmulator : 1
         });
     }
 }

--- a/src/profiles/full.slim.js
+++ b/src/profiles/full.slim.js
@@ -1,9 +1,9 @@
 /**
  * Zero-config full (slim) profile for libADLMIDI-JS
- * 
+ *
  * Exports pre-configured AdlMidi and AdlMidiCore with this profile's WASM.
  * Slim builds require loading a WOPL bank at runtime.
- * 
+ *
  * @module profiles/full.slim
  */
 
@@ -14,6 +14,10 @@ import { AdlMidiCore as BaseAdlMidiCore } from '../core.js';
 const PROCESSOR_URL = new URL('../../dist/libadlmidi.full.slim.processor.js', import.meta.url).href;
 const WASM_URL = new URL('../../dist/libadlmidi.full.slim.core.wasm', import.meta.url).href;
 const CORE_PATH = new URL('../../dist/libadlmidi.full.slim.core.js', import.meta.url).href;
+
+// Default synth settings injected at init. NUKED_FAST is preferred when the
+// profile bundles it (bit-exact vs Nuked 1.8, roughly 1.5x faster).
+const DEFAULT_SETTINGS = { emulator: 1 };
 
 /**
  * Pre-configured AdlMidi for full slim profile.
@@ -30,15 +34,17 @@ const CORE_PATH = new URL('../../dist/libadlmidi.full.slim.core.js', import.meta
 export class AdlMidi extends BaseAdlMidi {
     /**
      * Initialize the synthesizer with this profile's WASM.
-     * 
+     *
      * @param {string} [processorUrl] - Override processor URL (optional)
      * @param {string} [wasmUrl] - Override WASM URL (optional)
+     * @param {object} [defaultSettings] - Override profile's default synth settings
      * @returns {Promise<void>}
      */
-    async init(processorUrl, wasmUrl) {
+    async init(processorUrl, wasmUrl, defaultSettings) {
         return super.init(
             processorUrl || PROCESSOR_URL,
-            wasmUrl || WASM_URL
+            wasmUrl || WASM_URL,
+            defaultSettings || DEFAULT_SETTINGS
         );
     }
 }
@@ -60,13 +66,14 @@ export class AdlMidiCore {
     /**
      * Create a new AdlMidiCore instance with this profile's WASM.
      * 
-     * @param {{corePath?: string}} [options] - Options (corePath is pre-configured)
+     * @param {{corePath?: string, defaultEmulator?: number, wasmBinary?: ArrayBuffer}} [options]
+     *   Override profile defaults. corePath and defaultEmulator are pre-configured.
      * @returns {Promise<BaseAdlMidiCore>}
      */
     static async create(options = {}) {
         return BaseAdlMidiCore.create({
             ...options,
-            corePath: options.corePath || CORE_PATH
+            corePath: options.corePath || CORE_PATH, defaultEmulator: options.defaultEmulator !== undefined ? options.defaultEmulator : 1
         });
     }
 }

--- a/src/profiles/light.js
+++ b/src/profiles/light.js
@@ -1,9 +1,9 @@
 /**
  * Zero-config light profile for libADLMIDI-JS
- * 
+ *
  * Exports pre-configured AdlMidi and AdlMidiCore with this profile's WASM.
  * 
- * 
+ *
  * @module profiles/light
  */
 
@@ -14,6 +14,10 @@ import { AdlMidiCore as BaseAdlMidiCore } from '../core.js';
 const PROCESSOR_URL = new URL('../../dist/libadlmidi.light.processor.js', import.meta.url).href;
 const WASM_URL = new URL('../../dist/libadlmidi.light.core.wasm', import.meta.url).href;
 const CORE_PATH = new URL('../../dist/libadlmidi.light.core.js', import.meta.url).href;
+
+// Default synth settings injected at init. NUKED_FAST is preferred when the
+// profile bundles it (bit-exact vs Nuked 1.8, roughly 1.5x faster).
+const DEFAULT_SETTINGS = { emulator: 1 };
 
 /**
  * Pre-configured AdlMidi for light profile.
@@ -30,15 +34,17 @@ const CORE_PATH = new URL('../../dist/libadlmidi.light.core.js', import.meta.url
 export class AdlMidi extends BaseAdlMidi {
     /**
      * Initialize the synthesizer with this profile's WASM.
-     * 
+     *
      * @param {string} [processorUrl] - Override processor URL (optional)
      * @param {string} [wasmUrl] - Override WASM URL (optional)
+     * @param {object} [defaultSettings] - Override profile's default synth settings
      * @returns {Promise<void>}
      */
-    async init(processorUrl, wasmUrl) {
+    async init(processorUrl, wasmUrl, defaultSettings) {
         return super.init(
             processorUrl || PROCESSOR_URL,
-            wasmUrl || WASM_URL
+            wasmUrl || WASM_URL,
+            defaultSettings || DEFAULT_SETTINGS
         );
     }
 }
@@ -60,13 +66,14 @@ export class AdlMidiCore {
     /**
      * Create a new AdlMidiCore instance with this profile's WASM.
      * 
-     * @param {{corePath?: string}} [options] - Options (corePath is pre-configured)
+     * @param {{corePath?: string, defaultEmulator?: number, wasmBinary?: ArrayBuffer}} [options]
+     *   Override profile defaults. corePath and defaultEmulator are pre-configured.
      * @returns {Promise<BaseAdlMidiCore>}
      */
     static async create(options = {}) {
         return BaseAdlMidiCore.create({
             ...options,
-            corePath: options.corePath || CORE_PATH
+            corePath: options.corePath || CORE_PATH, defaultEmulator: options.defaultEmulator !== undefined ? options.defaultEmulator : 1
         });
     }
 }

--- a/src/profiles/light.slim.js
+++ b/src/profiles/light.slim.js
@@ -1,9 +1,9 @@
 /**
  * Zero-config light (slim) profile for libADLMIDI-JS
- * 
+ *
  * Exports pre-configured AdlMidi and AdlMidiCore with this profile's WASM.
  * Slim builds require loading a WOPL bank at runtime.
- * 
+ *
  * @module profiles/light.slim
  */
 
@@ -14,6 +14,10 @@ import { AdlMidiCore as BaseAdlMidiCore } from '../core.js';
 const PROCESSOR_URL = new URL('../../dist/libadlmidi.light.slim.processor.js', import.meta.url).href;
 const WASM_URL = new URL('../../dist/libadlmidi.light.slim.core.wasm', import.meta.url).href;
 const CORE_PATH = new URL('../../dist/libadlmidi.light.slim.core.js', import.meta.url).href;
+
+// Default synth settings injected at init. NUKED_FAST is preferred when the
+// profile bundles it (bit-exact vs Nuked 1.8, roughly 1.5x faster).
+const DEFAULT_SETTINGS = { emulator: 1 };
 
 /**
  * Pre-configured AdlMidi for light slim profile.
@@ -30,15 +34,17 @@ const CORE_PATH = new URL('../../dist/libadlmidi.light.slim.core.js', import.met
 export class AdlMidi extends BaseAdlMidi {
     /**
      * Initialize the synthesizer with this profile's WASM.
-     * 
+     *
      * @param {string} [processorUrl] - Override processor URL (optional)
      * @param {string} [wasmUrl] - Override WASM URL (optional)
+     * @param {object} [defaultSettings] - Override profile's default synth settings
      * @returns {Promise<void>}
      */
-    async init(processorUrl, wasmUrl) {
+    async init(processorUrl, wasmUrl, defaultSettings) {
         return super.init(
             processorUrl || PROCESSOR_URL,
-            wasmUrl || WASM_URL
+            wasmUrl || WASM_URL,
+            defaultSettings || DEFAULT_SETTINGS
         );
     }
 }
@@ -60,13 +66,14 @@ export class AdlMidiCore {
     /**
      * Create a new AdlMidiCore instance with this profile's WASM.
      * 
-     * @param {{corePath?: string}} [options] - Options (corePath is pre-configured)
+     * @param {{corePath?: string, defaultEmulator?: number, wasmBinary?: ArrayBuffer}} [options]
+     *   Override profile defaults. corePath and defaultEmulator are pre-configured.
      * @returns {Promise<BaseAdlMidiCore>}
      */
     static async create(options = {}) {
         return BaseAdlMidiCore.create({
             ...options,
-            corePath: options.corePath || CORE_PATH
+            corePath: options.corePath || CORE_PATH, defaultEmulator: options.defaultEmulator !== undefined ? options.defaultEmulator : 1
         });
     }
 }

--- a/src/profiles/nuked.js
+++ b/src/profiles/nuked.js
@@ -1,9 +1,9 @@
 /**
  * Zero-config nuked profile for libADLMIDI-JS
- * 
+ *
  * Exports pre-configured AdlMidi and AdlMidiCore with this profile's WASM.
  * 
- * 
+ *
  * @module profiles/nuked
  */
 
@@ -14,6 +14,10 @@ import { AdlMidiCore as BaseAdlMidiCore } from '../core.js';
 const PROCESSOR_URL = new URL('../../dist/libadlmidi.nuked.processor.js', import.meta.url).href;
 const WASM_URL = new URL('../../dist/libadlmidi.nuked.core.wasm', import.meta.url).href;
 const CORE_PATH = new URL('../../dist/libadlmidi.nuked.core.js', import.meta.url).href;
+
+// Default synth settings injected at init. NUKED_FAST is preferred when the
+// profile bundles it (bit-exact vs Nuked 1.8, roughly 1.5x faster).
+const DEFAULT_SETTINGS = { emulator: 1 };
 
 /**
  * Pre-configured AdlMidi for nuked profile.
@@ -30,15 +34,17 @@ const CORE_PATH = new URL('../../dist/libadlmidi.nuked.core.js', import.meta.url
 export class AdlMidi extends BaseAdlMidi {
     /**
      * Initialize the synthesizer with this profile's WASM.
-     * 
+     *
      * @param {string} [processorUrl] - Override processor URL (optional)
      * @param {string} [wasmUrl] - Override WASM URL (optional)
+     * @param {object} [defaultSettings] - Override profile's default synth settings
      * @returns {Promise<void>}
      */
-    async init(processorUrl, wasmUrl) {
+    async init(processorUrl, wasmUrl, defaultSettings) {
         return super.init(
             processorUrl || PROCESSOR_URL,
-            wasmUrl || WASM_URL
+            wasmUrl || WASM_URL,
+            defaultSettings || DEFAULT_SETTINGS
         );
     }
 }
@@ -60,13 +66,14 @@ export class AdlMidiCore {
     /**
      * Create a new AdlMidiCore instance with this profile's WASM.
      * 
-     * @param {{corePath?: string}} [options] - Options (corePath is pre-configured)
+     * @param {{corePath?: string, defaultEmulator?: number, wasmBinary?: ArrayBuffer}} [options]
+     *   Override profile defaults. corePath and defaultEmulator are pre-configured.
      * @returns {Promise<BaseAdlMidiCore>}
      */
     static async create(options = {}) {
         return BaseAdlMidiCore.create({
             ...options,
-            corePath: options.corePath || CORE_PATH
+            corePath: options.corePath || CORE_PATH, defaultEmulator: options.defaultEmulator !== undefined ? options.defaultEmulator : 1
         });
     }
 }

--- a/src/profiles/nuked.slim.js
+++ b/src/profiles/nuked.slim.js
@@ -1,9 +1,9 @@
 /**
  * Zero-config nuked (slim) profile for libADLMIDI-JS
- * 
+ *
  * Exports pre-configured AdlMidi and AdlMidiCore with this profile's WASM.
  * Slim builds require loading a WOPL bank at runtime.
- * 
+ *
  * @module profiles/nuked.slim
  */
 
@@ -14,6 +14,10 @@ import { AdlMidiCore as BaseAdlMidiCore } from '../core.js';
 const PROCESSOR_URL = new URL('../../dist/libadlmidi.nuked.slim.processor.js', import.meta.url).href;
 const WASM_URL = new URL('../../dist/libadlmidi.nuked.slim.core.wasm', import.meta.url).href;
 const CORE_PATH = new URL('../../dist/libadlmidi.nuked.slim.core.js', import.meta.url).href;
+
+// Default synth settings injected at init. NUKED_FAST is preferred when the
+// profile bundles it (bit-exact vs Nuked 1.8, roughly 1.5x faster).
+const DEFAULT_SETTINGS = { emulator: 1 };
 
 /**
  * Pre-configured AdlMidi for nuked slim profile.
@@ -30,15 +34,17 @@ const CORE_PATH = new URL('../../dist/libadlmidi.nuked.slim.core.js', import.met
 export class AdlMidi extends BaseAdlMidi {
     /**
      * Initialize the synthesizer with this profile's WASM.
-     * 
+     *
      * @param {string} [processorUrl] - Override processor URL (optional)
      * @param {string} [wasmUrl] - Override WASM URL (optional)
+     * @param {object} [defaultSettings] - Override profile's default synth settings
      * @returns {Promise<void>}
      */
-    async init(processorUrl, wasmUrl) {
+    async init(processorUrl, wasmUrl, defaultSettings) {
         return super.init(
             processorUrl || PROCESSOR_URL,
-            wasmUrl || WASM_URL
+            wasmUrl || WASM_URL,
+            defaultSettings || DEFAULT_SETTINGS
         );
     }
 }
@@ -60,13 +66,14 @@ export class AdlMidiCore {
     /**
      * Create a new AdlMidiCore instance with this profile's WASM.
      * 
-     * @param {{corePath?: string}} [options] - Options (corePath is pre-configured)
+     * @param {{corePath?: string, defaultEmulator?: number, wasmBinary?: ArrayBuffer}} [options]
+     *   Override profile defaults. corePath and defaultEmulator are pre-configured.
      * @returns {Promise<BaseAdlMidiCore>}
      */
     static async create(options = {}) {
         return BaseAdlMidiCore.create({
             ...options,
-            corePath: options.corePath || CORE_PATH
+            corePath: options.corePath || CORE_PATH, defaultEmulator: options.defaultEmulator !== undefined ? options.defaultEmulator : 1
         });
     }
 }

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -12,7 +12,9 @@
 export const Emulator = Object.freeze({
     /** Nuked OPL3 v1.8 - Most accurate, higher CPU usage */
     NUKED: 0,
-    /** Nuked OPL3 v1.7.4 - Slightly older version */
+    /** Optimized Nuked 1.8 fork by tgies with identical output */
+    NUKED_FAST: 1,
+    /** @deprecated Use NUKED_FAST */
     NUKED_174: 1,
     /** DosBox OPL3 - Good accuracy, lower CPU usage */
     DOSBOX: 2,

--- a/tests/fixtures/test-harness.html
+++ b/tests/fixtures/test-harness.html
@@ -34,7 +34,11 @@
                 await ctx.audioWorklet.addModule('../../dist/libadlmidi.nuked.processor.js');
 
                 const node = new AudioWorkletNode(ctx, 'adl-midi-processor', {
-                    processorOptions: { sampleRate, wasmBinary }
+                    processorOptions: {
+                        sampleRate,
+                        wasmBinary,
+                        settings: { emulator: 1 /* NUKED_FAST */ }
+                    }
                 });
                 node.connect(ctx.destination);
 
@@ -102,7 +106,11 @@
                 await ctx.audioWorklet.addModule('../../dist/libadlmidi.nuked.processor.js');
 
                 const node = new AudioWorkletNode(ctx, 'adl-midi-processor', {
-                    processorOptions: { sampleRate, wasmBinary }
+                    processorOptions: {
+                        sampleRate,
+                        wasmBinary,
+                        settings: { emulator: 1 /* NUKED_FAST */ }
+                    }
                 });
                 node.connect(ctx.destination);
 
@@ -196,7 +204,8 @@
                 const node = new AudioWorkletNode(ctx, 'adl-midi-processor', {
                     processorOptions: {
                         sampleRate,
-                        wasmBinary  // This is the key - pass pre-fetched WASM
+                        wasmBinary,  // This is the key - pass pre-fetched WASM
+                        settings: { emulator: 1 /* NUKED_FAST */ }
                     }
                 });
                 node.connect(ctx.destination);
@@ -265,7 +274,11 @@
                 await ctx.audioWorklet.addModule(processorUrl);
 
                 const node = new AudioWorkletNode(ctx, 'adl-midi-processor', {
-                    processorOptions: { sampleRate, wasmBinary }
+                    processorOptions: {
+                        sampleRate,
+                        wasmBinary,
+                        settings: { emulator: 1 /* NUKED_FAST */ }
+                    }
                 });
                 node.connect(ctx.destination);
 

--- a/tests/fixtures/test-vectors.json
+++ b/tests/fixtures/test-vectors.json
@@ -1,6 +1,6 @@
 {
     "_comment": "Golden master test vectors for libADLMIDI-JS audio output verification",
-    "_generated": "2026-05-13",
+    "_generated": "2026-05-25",
     "_note": "These hashes are captured from known-good renders. If they change unexpectedly, it may indicate a regression.",
     "browser": {
         "note_c4_bank72_500ms": {
@@ -14,16 +14,16 @@
             "hash": "ef476ff77703e54f5f35a7d3b4c7f9e8b6a5c4d3e2f1a0b98765432109876543"
         },
         "imf_mamsnake_3s": {
-            "description": "mamsnake.imf (Wolf3D music) playback for 3 seconds",
+            "description": "mamsnake.imf (Wolf3D music) playback for 3 seconds, NUKED_FAST emulator",
             "file": "test-files/mamsnake.imf",
             "durationMs": 3000,
-            "hash": "aa25dde84973da57c4126513b6e5418a9165f31163c8c21bb68f14860de3934b"
+            "hash": "608e70b5834f5fec540dac3aac890608d4a51452f1b9b1f5a425b281d08c12e3"
         },
         "midi_canyon_3s": {
-            "description": "canyon.mid (classic Windows MIDI) playback for 3 seconds",
+            "description": "canyon.mid (classic Windows MIDI) playback for 3 seconds, NUKED_FAST emulator",
             "file": "test-files/canyon.mid",
             "durationMs": 3000,
-            "hash": "e7514fe96bd0e4800926642a772e24115a362f5fe06e4a62d5a92a7968105359"
+            "hash": "5fc65936e8295811230a17538011bcb476be12ae9d87db5d8b0cc8a16ed07c34"
         }
     },
     "node": {


### PR DESCRIPTION
Repoint submodule from tgies/libADLMIDI to Wohlstand/libADLMIDI master. Upstream now includes the Nuked-OPL3-fast variant as a separate nuked_fast module. Rename Emulator.NUKED_174 to NUKED_FAST (alias kept), have the nuked/light/full profile wrappers inject it as the runtime default via new defaultSettings (AdlMidi.init) and defaultEmulator (AdlMidiCore.create) options. Browser test hashes re-baselined for the new default (previous upstream had inaccurate optimizations).