### PR TITLE
chore: release v2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libadlmidi-js",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "libadlmidi": {
     "version": "1.6.2",
     "commit": "6528dafce641e81ded5d62809445267b82dc0d8d"


### PR DESCRIPTION
## Summary

Bump version to 2.1.0. Changes since 2.0.0:

- Default emulator switched from NUKED to NUKED_FAST for nuked/light/full profiles. NUKED_FAST is bit-exact to upstream Nuke.YKT v1.8 canonical Sin functions and roughly 1.5x faster. Users can opt back via `init(undefined, undefined, { emulator: Emulator.NUKED })`.
- `Emulator.NUKED_FAST` replaces `Emulator.NUKED_174` (alias kept).
- `AdlMidi.init()` accepts optional third `defaultSettings` argument; `AdlMidiCore.create()` accepts optional `defaultEmulator` option.
- Submodule repointed from `tgies/libADLMIDI` to `Wohlstand/libADLMIDI` master (`6528daf`), which includes the upstream Nuked-OPL3-fast module with the buffered-writeReg fix and 2048-entry writebuf.
- TypeScript type declarations added to all profile export conditions in package.json.
- Dependabot (npm + github-actions + gitsubmodule), CodeQL, husky + commitlint + lint-staged, publint + attw, actionlint, npm audit, concurrency cancel-in-progress, zizmor findings addressed.
- Nuked OPL3 Fast added to oplsfxr.html emulator dropdown.